### PR TITLE
feat: sellingpartnerapi requests pkg v0

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,23 +3,26 @@ package main
 import (
 	"fmt"
 	"joubini/pkg/aws"
+	orderItems "joubini/pkg/sellingpartnerapi/orderitems"
+	"joubini/pkg/sellingpartnerapi/orders"
 	"joubini/pkg/utils"
 )
 
 func main() {
-	roleARN := utils.GetEnv("AWS_ROLE_ARN", "")
-	sessionName := utils.GetEnv("AWS_SESSION_NAME", "test")
-  region := utils.GetEnv("AWS_DEFAULT_REGION", "us-east-1")
-  
-  cred := aws.STSCredentials(roleARN, sessionName, region)
+	clientId := utils.GetEnv("LWA_ID", "")
+	clientSecret := utils.GetEnv("LWA_SECRET", "")
+	refreshToken := utils.GetEnv("LWA_REFRESH_TOKEN", "")
 
-  fmt.Println(*cred.AccessKeyId)
+	token := aws.GetToken(clientId, clientSecret, refreshToken)
 
-  clientId := utils.GetEnv("LWA_ID", "")
-  clientSecret := utils.GetEnv("LWA_SECRET", "")
-  refreshToken := utils.GetEnv("LWA_REFRESH_TOKEN", "")
+	fmt.Println(token.AccessToken)
 
-  token := aws.GetToken(clientId, clientSecret, refreshToken)
+	yesterday := utils.DateNowSubtractFormated("2006-01-02", 1)
+	fmt.Println("today", yesterday)
 
-  fmt.Println(token.AccessToken)
+	order, _ := orders.GetOrders(token.AccessToken, yesterday)
+	amazonOrderId := order[len(order)-1].AmazonOrderId
+	orderItems, _ := orderItems.GetOrderItems(token.AccessToken, amazonOrderId)
+	fmt.Println("order", order)
+	fmt.Println("orderItems", orderItems)
 }

--- a/pkg/sellingpartnerapi/orderitems/getorderitems.go
+++ b/pkg/sellingpartnerapi/orderitems/getorderitems.go
@@ -1,0 +1,105 @@
+package orderItems
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func GetOrderItems(accessToken string, amazonOrderId string) ([]OrderItem, error) {
+	urlBase := "https://sellingpartnerapi-na.amazon.com/orders/v0/orders/"
+	url := urlBase + amazonOrderId + "/orderItems"
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Println("error could not create request:", err)
+		return nil, err
+	}
+
+	req.Header.Set("x-amz-access-token", accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println("error could not execute request:", err)
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Printf("error could not read response body: %s\n", err)
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		var errResponse ErrorResponse
+		if err := json.Unmarshal([]byte(body), &errResponse); err != nil {
+			fmt.Println("error unmarshal JSON:", err)
+			return nil, err
+		}
+		fmt.Printf("error request response: %s\n", body)
+		return nil, errors.New(errResponse.Errors[0].Message)
+	}
+
+	var data Root
+	if err := json.Unmarshal([]byte(body), &data); err != nil {
+		fmt.Println("error unmarshal JSON:", err)
+		return nil, err
+	}
+
+	return data.Payload.OrderItems, nil
+}
+
+type ErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Details string `json:"details"`
+}
+
+type ErrorResponse struct {
+	Errors []ErrorDetail `json:"errors"`
+}
+
+type ProductInfo struct {
+	NumberOfItems string `json:"NumberOfItems"`
+}
+
+type ItemTax struct {
+	CurrencyCode string `json:"CurrencyCode"`
+	Amount       string `json:"Amount"`
+}
+
+type ItemPrice struct {
+	CurrencyCode string `json:"CurrencyCode"`
+	Amount       string `json:"Amount"`
+}
+
+type OrderItem struct {
+	ProductInfo          ProductInfo `json:"ProductInfo"`
+	BuyerInfo            struct{}    `json:"BuyerInfo"`
+	ItemTax              ItemTax     `json:"ItemTax"`
+	QuantityShipped      int         `json:"QuantityShipped"`
+	ItemPrice            ItemPrice   `json:"ItemPrice"`
+	ASIN                 string      `json:"ASIN"`
+	SellerSKU            string      `json:"SellerSKU"`
+	Title                string      `json:"Title"`
+	IsGift               string      `json:"IsGift"`
+	IsTransparency       bool        `json:"IsTransparency"`
+	QuantityOrdered      int         `json:"QuantityOrdered"`
+	PromotionDiscountTax ItemTax     `json:"PromotionDiscountTax"`
+	PromotionDiscount    ItemTax     `json:"PromotionDiscount"`
+	OrderItemId          string      `json:"OrderItemId"`
+}
+
+type Payload struct {
+	OrderItems    []OrderItem `json:"OrderItems"`
+	AmazonOrderId string      `json:"AmazonOrderId"`
+}
+
+type Root struct {
+	Payload Payload `json:"payload"`
+}

--- a/pkg/sellingpartnerapi/orders/getorders.go
+++ b/pkg/sellingpartnerapi/orders/getorders.go
@@ -1,0 +1,124 @@
+package orders
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func GetOrders(accessToken string, createdAfter string) ([]Order, error) {
+	urlBase := "https://sellingpartnerapi-na.amazon.com/orders/v0/orders?MarketplaceIds=A2Q3Y263D00KWC"
+	url := urlBase + "&CreatedAfter=" + createdAfter
+
+	req, err := http.NewRequest(http.MethodGet, url, nil)
+	if err != nil {
+		fmt.Println("error could not create request:", err)
+		return nil, err
+	}
+
+	req.Header.Set("x-amz-access-token", accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		fmt.Println("error could not execute request:", err)
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	body, err := io.ReadAll(res.Body)
+	if err != nil {
+		fmt.Printf("error could not read response body: %s\n", err)
+		return nil, err
+	}
+
+	if res.StatusCode != 200 {
+		var errResponse ErrorResponse
+		if err := json.Unmarshal([]byte(body), &errResponse); err != nil {
+			fmt.Println("error unmarshal JSON:", err)
+			return nil, err
+		}
+		fmt.Printf("error request response: %s\n", body)
+		return nil, errors.New(errResponse.Errors[0].Message)
+	}
+
+	var data Root
+	if err := json.Unmarshal([]byte(body), &data); err != nil {
+		fmt.Println("error unmarshal JSON:", err)
+		return nil, err
+	}
+
+	return data.Payload.Orders, nil
+}
+
+type ErrorDetail struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+	Details string `json:"details"`
+}
+
+type ErrorResponse struct {
+	Errors []ErrorDetail `json:"errors"`
+}
+
+type BuyerInfo struct {
+	BuyerEmail  string `json:"BuyerEmail"`
+	BuyerCounty string `json:"BuyerCounty"`
+}
+
+type ShippingAddress struct {
+	StateOrRegion string `json:"StateOrRegion"`
+	PostalCode    string `json:"PostalCode"`
+	City          string `json:"City"`
+	CountryCode   string `json:"CountryCode"`
+}
+
+type OrderTotal struct {
+	CurrencyCode string `json:"CurrencyCode"`
+	Amount       string `json:"Amount"`
+}
+
+type Order struct {
+	BuyerInfo                    BuyerInfo       `json:"BuyerInfo"`
+	AmazonOrderId                string          `json:"AmazonOrderId"`
+	EarliestShipDate             string          `json:"EarliestShipDate"`
+	SalesChannel                 string          `json:"SalesChannel"`
+	OrderStatus                  string          `json:"OrderStatus"`
+	NumberOfItemsShipped         int             `json:"NumberOfItemsShipped"`
+	OrderType                    string          `json:"OrderType"`
+	IsPremiumOrder               bool            `json:"IsPremiumOrder"`
+	IsPrime                      bool            `json:"IsPrime"`
+	FulfillmentChannel           string          `json:"FulfillmentChannel"`
+	NumberOfItemsUnshipped       int             `json:"NumberOfItemsUnshipped"`
+	HasRegulatedItems            bool            `json:"HasRegulatedItems"`
+	IsReplacementOrder           string          `json:"IsReplacementOrder"`
+	IsSoldByAB                   bool            `json:"IsSoldByAB"`
+	LatestShipDate               string          `json:"LatestShipDate"`
+	ShipServiceLevel             string          `json:"ShipServiceLevel"`
+	IsISPU                       bool            `json:"IsISPU"`
+	MarketplaceId                string          `json:"MarketplaceId"`
+	PurchaseDate                 string          `json:"PurchaseDate"`
+	ShippingAddress              ShippingAddress `json:"ShippingAddress"`
+	IsAccessPointOrder           bool            `json:"IsAccessPointOrder"`
+	SellerOrderId                string          `json:"SellerOrderId"`
+	PaymentMethod                string          `json:"PaymentMethod"`
+	IsBusinessOrder              bool            `json:"IsBusinessOrder"`
+	OrderTotal                   OrderTotal      `json:"OrderTotal"`
+	PaymentMethodDetails         []string        `json:"PaymentMethodDetails"`
+	IsGlobalExpressEnabled       bool            `json:"IsGlobalExpressEnabled"`
+	LastUpdateDate               string          `json:"LastUpdateDate"`
+	ShipmentServiceLevelCategory string          `json:"ShipmentServiceLevelCategory"`
+}
+
+type Payload struct {
+	Orders        []Order `json:"Orders"`
+	NextToken     string  `json:"NextToken"`
+	CreatedBefore string  `json:"CreatedBefore"`
+}
+
+type Root struct {
+	Payload Payload `json:"payload"`
+}

--- a/pkg/utils/date.go
+++ b/pkg/utils/date.go
@@ -1,0 +1,11 @@
+package utils
+
+import (
+	"time"
+)
+
+func DateNowSubtractFormated(pattern string, days int) string {
+	today := time.Now()
+	before := today.AddDate(0, 0, -days)
+	return before.Format(pattern)
+}


### PR DESCRIPTION
## Description

Adding HTTP request to GET orders and oderItems from selling partner api

## Test Details

<!-- Example:
- I tested the happy path
- I tested the unhappy path
- Here's a random edge case I tested
- Unit test coverage of 80%
- Added e2e tests
-->

For more information please review the details at [Google Engineering](https://google.github.io/eng-practices/review/).
